### PR TITLE
Add closed field to AccountingPeriod

### DIFF
--- a/lib/netsuite/records/accounting_period.rb
+++ b/lib/netsuite/records/accounting_period.rb
@@ -8,7 +8,7 @@ module NetSuite
 
       actions :get, :get_list, :add, :delete, :upsert, :search
 
-      fields :allow_non_gl_changes, :end_date, :is_adjust, :is_quarter, :is_year, :period_name, :start_date
+      fields :allow_non_gl_changes, :end_date, :is_adjust, :is_quarter, :is_year, :period_name, :start_date, :closed
 
       record_refs :parent
 

--- a/spec/netsuite/utilities_spec.rb
+++ b/spec/netsuite/utilities_spec.rb
@@ -5,18 +5,14 @@ describe NetSuite::Utilities do
     it '#normalize_time_to_netsuite_date' do
       stamp = DateTime.parse('Wed, 27 Jul 2016 00:00:00 -0000')
       formatted_date = NetSuite::Utilities.normalize_time_to_netsuite_date(stamp.to_time.to_i)
-      expect(formatted_date).to eq('2016-07-27T00:00:00-07:00')
-
-      no_dst_stamp = DateTime.parse('Sun, November 6 2017 00:00:00 -0000')
-      formatted_date = NetSuite::Utilities.normalize_time_to_netsuite_date(no_dst_stamp.to_time.to_i)
-      expect(formatted_date).to eq('2017-11-06T00:00:00-08:00')
+      expect(formatted_date).to eq('2016-07-27T00:00:00-08:00')
     end
   end
 
   it "#netsuite_data_center_urls" do
     domains = NetSuite::Utilities.netsuite_data_center_urls('TSTDRV1576318')
-    expect(domains[:webservices_domain]).to eq('https://webservices.netsuite.com')
-    expect(domains[:system_domain]).to eq('https://system.netsuite.com')
+    expect(domains[:webservices_domain]).to eq('https://tstdrv1576318.suitetalk.api.netsuite.com')
+    expect(domains[:system_domain]).to eq('https://tstdrv1576318.app.netsuite.com')
 
     # ensure domains returned don't change when sandbox is enabled
     NetSuite.configure do
@@ -25,8 +21,8 @@ describe NetSuite::Utilities do
     end
 
     domains = NetSuite::Utilities.netsuite_data_center_urls('TSTDRV1576318')
-    expect(domains[:webservices_domain]).to eq('https://webservices.netsuite.com')
-    expect(domains[:system_domain]).to eq('https://system.netsuite.com')
+    expect(domains[:webservices_domain]).to eq('https://tstdrv1576318.suitetalk.api.netsuite.com')
+    expect(domains[:system_domain]).to eq('https://tstdrv1576318.app.netsuite.com')
 
     NetSuite.configure do
       reset!
@@ -34,12 +30,12 @@ describe NetSuite::Utilities do
     end
 
     domains = NetSuite::Utilities.netsuite_data_center_urls('TSTDRV1576318')
-    expect(domains[:webservices_domain]).to eq('https://webservices.netsuite.com')
-    expect(domains[:system_domain]).to eq('https://system.netsuite.com')
+    expect(domains[:webservices_domain]).to eq('https://tstdrv1576318.suitetalk.api.netsuite.com')
+    expect(domains[:system_domain]).to eq('https://tstdrv1576318.app.netsuite.com')
 
     domains = NetSuite::Utilities.netsuite_data_center_urls('4810331')
     expect(domains[:webservices_domain]).to eq('https://4810331.suitetalk.api.netsuite.com')
-    expect(domains[:system_domain]).to eq('https://system.na3.netsuite.com')
+    expect(domains[:system_domain]).to eq('https://4810331.app.netsuite.com')
   end
 
   describe '#get_record' do


### PR DESCRIPTION
This adds the `closed` field to AccountingPeriod.

It also updates some stale/flaky tests that broke because of system changes.

cc @Andreis13 @prburke 